### PR TITLE
Add check in " case _GestureState.PointerDown" to fix onTap ignoring.

### DIFF
--- a/lib/gesture_x_detector.dart
+++ b/lib/gesture_x_detector.dart
@@ -182,6 +182,8 @@ class _XGestureDetectorState extends State<XGestureDetector> {
         }
         break;
       case _GestureState.PointerDown:
+       if (event.localDelta.distanceSquared == 0) break;
+
         switch2MoveStartState(touch, event);
         break;
       case _GestureState.MoveStart:


### PR DESCRIPTION
Fix ignoring onPointerDown on real device. Fix #19 
Have a nice day.